### PR TITLE
Resolve #544 : refactor RawToNWBBuilder for easier workflow

### DIFF
--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -160,18 +160,7 @@ class RawToNWBBuilder:
         os.makedirs(self.video_path, exist_ok=True)
         for date in self.dates:
             logger.info('Date: {}'.format(date))
-            nwb_builder = NWBFileBuilder(
-                data_path=self.data_path,
-                animal_name=self.animal_name,
-                date=date,
-                nwb_metadata=self.nwb_metadata,
-                output_file=self.output_path + self.animal_name + date + ".nwb",
-                process_mda=self.extract_mda,
-                process_dio=self.extract_dio,
-                process_analog=self.extract_analog,
-                video_path=self.video_path,
-                reconfig_header=self.__is_rec_config_valid()
-            )
+            nwb_builder = self.get_nwb_builder(date)
             content = nwb_builder.build()
             nwb_builder.write(content)
             self.append_to_nwb(
@@ -181,6 +170,20 @@ class RawToNWBBuilder:
                 process_pos_valid_time=process_pos_valid_time,
                 process_pos_invalid_time=process_pos_invalid_time
             )
+
+    def get_nwb_builder(self, date):
+        return NWBFileBuilder(
+            data_path=self.data_path,
+            animal_name=self.animal_name,
+            date=date,
+            nwb_metadata=self.nwb_metadata,
+            output_file=self.output_path + self.animal_name + date + ".nwb",
+            process_mda=self.extract_mda,
+            process_dio=self.extract_dio,
+            process_analog=self.extract_analog,
+            video_path=self.video_path,
+            reconfig_header=self.__is_rec_config_valid()
+        )
 
     def __preprocess_data(self):
         """process data with rec_to_binaries library"""

--- a/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
+++ b/rec_to_nwb/processing/builder/raw_to_nwb_builder.py
@@ -147,7 +147,19 @@ class RawToNWBBuilder:
         """
 
         self.__preprocess_data()
+
+        self.__build_nwb_file(process_mda_valid_time=process_mda_valid_time,
+            process_mda_invalid_time=process_mda_invalid_time,
+            process_pos_valid_time=process_pos_valid_time,
+            process_pos_invalid_time=process_pos_invalid_time)
+
+    def __build_nwb_file(self, process_mda_valid_time=True, process_mda_invalid_time=True,
+               process_pos_valid_time=True, process_pos_invalid_time=True):
+        logger.info('Building NWB files')
+        os.makedirs(self.output_path, exist_ok=True)
+        os.makedirs(self.video_path, exist_ok=True)
         for date in self.dates:
+            logger.info('Date: {}'.format(date))
             nwb_builder = NWBFileBuilder(
                 data_path=self.data_path,
                 animal_name=self.animal_name,
@@ -241,4 +253,3 @@ class RawToNWBBuilder:
         preprocessing = self.data_path + '/' + self.animal_name + '/preprocessing'
         if os.path.exists(preprocessing):
             shutil.rmtree(preprocessing)
-


### PR DESCRIPTION
This resolves #544 for me.

After constructing a RawToNWBBuilder,

```python
builder = RawToNWBBuilder(**all_my_kwargs)
```

- User-developer can now run the NWB builder part separately. Kept this a private function to match with the existing method `__preprocess_data()`. Ideally this separation is not needed if everything "just works".

    ```python
    builder._RawToNWBBuilder__build_nwb_file()
    ```

- User can also extract a matching NWBFileBuilder for a specific day:

   ```python
   builder.get_nwb_builder('20170901')
   ```