### PR TITLE
Fix #542: Fix default header comparison

### DIFF
--- a/rec_to_nwb/processing/nwb/components/device/header/fl_header_device_manager.py
+++ b/rec_to_nwb/processing/nwb/components/device/header/fl_header_device_manager.py
@@ -13,6 +13,6 @@ class FlHeaderDeviceManager:
 
     def __compare_global_configuration_with_default(self):
         for single_key in self.default_configuration:
-            if single_key not in self.global_configuration.keys():
+            if single_key not in self.global_configuration.keys() or self.global_configuration[single_key] is None:
                 self.global_configuration[single_key] = self.default_configuration[single_key]
         return self.global_configuration


### PR DESCRIPTION
Fix #542 .

Missing keys were already populated with `None`, so the previous comparison didn't catch them.