### PR TITLE
Attempt to resolve #543: skip missing position data

### DIFF
--- a/rec_to_nwb/processing/nwb/components/position/fl_position_extractor.py
+++ b/rec_to_nwb/processing/nwb/components/position/fl_position_extractor.py
@@ -26,6 +26,9 @@ class FlPositionExtractor:
                     'Incomplete data in dataset '
                     + str(dataset.name)
                     + 'missing continuous time file')
+            if len(data_from_current_dataset) == 0:
+                # otherwise get IndexError downstream (PosDataManager)
+                continue
             all_pos.append(data_from_current_dataset)
             continuous_time.append(dataset.get_continuous_time())
         return all_pos, continuous_time


### PR DESCRIPTION
This is an attempt to resolve #543. Works for me at the moment, but not sure if this is the "right" way to go.

Previously, an empty list was appended to `all_pos` when the .videoPositionTracking file was missing. This resulted in an IndexError downstream. This fix just skips that empty list.